### PR TITLE
Replaces `mysql_error` call.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === wp2syslog ===
 Contributors: psicosi448
-Donate link: 
+Donate link:
 Tags: logging,events,actions,syslog
 Requires at least: 3.3
 Tested up to: 4.2
@@ -12,13 +12,13 @@ wp2syslog -- Global logging facility for WordPress (WPsyslog revisited)
 
 == Description ==
 
-**End users can benefit from wp2syslog:**   
+**End users can benefit from wp2syslog:**
 
 *	Log entries for core events help to keep track of the daily business, especially on multiuser blogs.
 *	Log entries for core events can raise awareness for threats and problems, for example abuse attempts.
 *	Log entries triggered by plugins allow the user to comprehend the functionality of the plugin.
 
-**Developers can benefit in two ways from wp2syslog:**  
+**Developers can benefit in two ways from wp2syslog:**
 
 * At each point of the code, a log entry can be triggered. No need to print to the browser, just let wp2syslog put it in the database, and you can have a look later.
 * You can develop your plugins with support for wp2syslog. This will give your users the chance to better understand what your plugin is doing (see doc/specs.html).
@@ -39,6 +39,9 @@ wp2syslog -- Global logging facility for WordPress (WPsyslog revisited)
 2. Show log, with query filter
 
 == Changelog ==
+
+= 1.0.5 -
+* fix: removed mysql_error call in favor of $wpdb->last_error
 
 = 1.0.4 =
 * fix: load css only in showlog page

--- a/wp2syslog.php
+++ b/wp2syslog.php
@@ -85,7 +85,7 @@ class WP2SYSLOG{
 						{
 								update_option('wp2syslog_version_num', WP2SYSLOG_VERSION_NUM);
 						}
-						
+
 						//Force a config state and init() again ..
 						$this->set_init_status('config');
 						$this->init();
@@ -94,7 +94,7 @@ class WP2SYSLOG{
 
 				$check_options=$this->settings->get_options();
 				if($this->init_status=='config' && $check_options['db']=='true' )
-				{ 
+				{
 						//OK, let's go to create or upgrade wp2syslog table
 						$this->wp2syslog('wp2syslog', __('wp2syslog is going to create table ..', 'wp2syslog'), 2);
 
@@ -239,7 +239,7 @@ class WP2SYSLOG{
 
 						if ( false === $result)
 						{
-								syslog(LOG_WARNING, "$block_header $severityname: MYSQLERROR ".mysql_error());
+								syslog(LOG_WARNING, "$block_header $severityname: MYSQLERROR ".$wpdb->last_error);
 								return false;
 						}
 				}

--- a/wp2syslog.php
+++ b/wp2syslog.php
@@ -4,7 +4,7 @@
    Plugin URI: https://github.com/kataweb/wp2syslog
    Description: It keeps track of wordpress's events and log them to syslog.
    Author: psicosi448
-   Version: 1.0.4
+   Version: 1.0.5
    Author URI: http://www.kataweb.it
  */
 
@@ -24,7 +24,7 @@ define('WP2SYSLOG_PLUGIN_NAME', trim(dirname(plugin_basename(__FILE__)), '/'));
 if (!defined('WP2SYSLOG_PLUGIN_DIR'))
 define('WP2SYSLOG_PLUGIN_DIR', WP_PLUGIN_DIR . '/' . WP2SYSLOG_PLUGIN_NAME);
 if (!defined('WP2SYSLOG_VERSION_NUM'))
-define('WP2SYSLOG_VERSION_NUM', '1.0.4');
+define('WP2SYSLOG_VERSION_NUM', '1.0.5');
 
 require_once(WP2SYSLOG_PLUGIN_DIR.'/wp2syslog_settings.php');
 require_once(WP2SYSLOG_PLUGIN_DIR.'/wp2syslog_showlog.php');


### PR DESCRIPTION
Support for the `mysql_*` functions was deprecated in 5.5 and removed entirely in 7. This patch replaces a single call to `mysql_error()` with `$wpdb->last_error`, delegating the DBI work to WordPress core.